### PR TITLE
Update start time to be a less abrasive entrance

### DIFF
--- a/main.js
+++ b/main.js
@@ -62,7 +62,7 @@ $(function() {
       audio.load();
 
       if (skip_intro && !ep.live) {
-        audio.currentTime = 40;
+        audio.currentTime = 45;
       }
     }
 


### PR DESCRIPTION
The 40s mark is a little abrasive, I find the jolt in volume frustrating. Moving it to 45s has increased the chance of missing one or two words, but across all the episodes I've listened to it's very rare and works with the new opening too.